### PR TITLE
fix: detect package version from filename in CI

### DIFF
--- a/Pharmica.AssetGen.Tests/Integration/IntegrationTestHooks.cs
+++ b/Pharmica.AssetGen.Tests/Integration/IntegrationTestHooks.cs
@@ -33,7 +33,18 @@ public static class IntegrationTestHooks
 
         if (isCI && Directory.Exists(LocalNuGetDir))
         {
-            // Use the version that the CI workflow already packed
+            // Detect version from the .nupkg file
+            var existingPackages = Directory.GetFiles(LocalNuGetDir, "Pharmica.AssetGen.*.nupkg");
+            if (existingPackages.Length > 0)
+            {
+                var packageFile = Path.GetFileName(existingPackages[0]);
+                // Extract version from filename: Pharmica.AssetGen.1.0.1.nupkg -> 1.0.1
+                var version = packageFile.Replace("Pharmica.AssetGen.", "").Replace(".nupkg", "");
+                TestVersion = version;
+                return;
+            }
+
+            // Fallback to 0.0.0-ci if no package found
             TestVersion = "0.0.0-ci";
             return;
         }


### PR DESCRIPTION
## Description

Fixed integration tests failing in the release workflow by detecting the actual package version from the `.nupkg` filename instead of hardcoding it to `0.0.0-ci`. The release workflow packs the generator with the actual version from the git tag, but tests were looking for the wrong version.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] CI/CD changes
- [ ] Dependency updates

## Related Issues

Fixes release workflow failure when deploying v1.0.1

## Changes Made

- Updated `IntegrationTestHooks.cs` to detect version from `.nupkg` filename in CI
- Extracts version from filename pattern: `Pharmica.AssetGen.1.0.1.nupkg` ÔåÆ `1.0.1`
- Falls back to `0.0.0-ci` if no package found (safety net)
- Local development behavior unchanged (still generates unique test versions)

## Testing

### Test Cases

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Environment

- OS: Ubuntu 24.04.3 LTS
- .NET SDK Version: 9.0.9
- IDE: CLI

### How to Test

1. Run `dotnet test --configuration Release` locally - should pass
2. Merge to main and push tag `v1.0.1`
3. Verify release workflow tests pass in CI

## Breaking Changes

None - this is a test infrastructure fix only.

## Documentation

- [ ] README updated (if needed) - N/A
- [x] Code comments added/updated
- [ ] CHANGELOG.md updated - N/A (internal test fix)
- [ ] API documentation updated (if applicable) - N/A

## Screenshots / Examples

**Before (hardcoded):**
```csharp
if (isCI && Directory.Exists(LocalNuGetDir))
{
    TestVersion = "0.0.0-ci"; // Always hardcoded
    return;
}
```

**After (dynamic):**
```csharp
if (isCI && Directory.Exists(LocalNuGetDir))
{
    var existingPackages = Directory.GetFiles(LocalNuGetDir, "Pharmica.AssetGen.*.nupkg");
    if (existingPackages.Length > 0)
    {
        var packageFile = Path.GetFileName(existingPackages[0]);
        var version = packageFile.Replace("Pharmica.AssetGen.", "").Replace(".nupkg", "");
        TestVersion = version; // Dynamically detected: 1.0.1, 1.0.2, etc.
        return;
    }
    TestVersion = "0.0.0-ci"; // Fallback
    return;
}
```

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A (test infrastructure change)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published - N/A
- [x] I have checked my code and corrected any misspellings
- [x] Commit messages follow the Conventional Commits specification

## Additional Notes

This fix is required for the release workflow to succeed. The issue occurred because:

1. PR workflow uses `0.0.0-ci` (hardcoded) - works fine
2. Release workflow uses actual version from git tag (e.g., `1.0.1`)
3. Tests were still looking for `0.0.0-ci` package, causing "file not found" errors

Now the tests dynamically detect whatever version was packed, making the release workflow work correctly.
